### PR TITLE
[WIP] Remove FluentAssertions dependency

### DIFF
--- a/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
+++ b/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
@@ -13,7 +13,6 @@
   
   <ItemGroup>
     <PackageReference Include="Akka.Hosting.TestKit" />
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/src/Akka.Persistence.MongoDb.Tests/Bug61FixSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/Bug61FixSpec.cs
@@ -5,7 +5,6 @@ using Akka.Persistence.MongoDb.Query;
 using Akka.Persistence.Query;
 using Akka.Streams;
 using Akka.Util.Internal;
-using FluentAssertions;
 using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Misc;
 using System;
@@ -62,15 +61,15 @@ namespace Akka.Persistence.MongoDb.Tests
             var eventsById = await ReadJournal.CurrentEventsByPersistenceId("x", 0L, long.MaxValue)
                 .RunAggregate(ImmutableHashSet<EventEnvelope>.Empty, (agg, e) => agg.Add(e), Materializer);
 
-            eventsById.Count.Should().Be(MessageCount);
+            Assert.Equal(MessageCount, eventsById.Count);
 
             var eventsByTag = await ReadJournal.CurrentEventsByTag(typeof(RealMsg).Name)
                 .RunAggregate(ImmutableHashSet<EventEnvelope>.Empty, (agg, e) => agg.Add(e), Materializer);
 
-            eventsByTag.Count.Should().Be(MessageCount);
+            Assert.Equal(MessageCount, eventsByTag.Count);
 
-            eventsById.All(x => x.Event is RealMsg).Should().BeTrue("Expected all events by id to be RealMsg");
-            eventsByTag.All(x => x.Event is RealMsg).Should().BeTrue("Expected all events by tag to be RealMsg");
+            Assert.True(eventsById.All(x => x.Event is RealMsg));
+            Assert.True(eventsByTag.All(x => x.Event is RealMsg));
         }
 
         /// <summary>

--- a/src/Akka.Persistence.MongoDb.Tests/GridFS/MongoDbGridFsLegacySerializationSnapshotStoreSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/GridFS/MongoDbGridFsLegacySerializationSnapshotStoreSpec.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="MongoDbSnapshotStoreSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 using Akka.Configuration;
 using Akka.Event;
 using Akka.Persistence.TCK.Snapshot;
-using FluentAssertions;
 using Xunit;
 
 #nullable enable
@@ -79,7 +78,6 @@ public class MongoDbGridFsLegacySerializationSnapshotStoreSpec : SnapshotStoreSp
         stopwatch.Stop();
         Log.Info($"{SnapshotByteSizeLimit} bytes snapshot loaded in {stopwatch.Elapsed.Milliseconds} milliseconds");
         
-        MD5.Create().ComputeHash((byte[])loaded.Snapshot.Snapshot).Should()
-            .BeEquivalentTo(MD5.Create().ComputeHash(bigSnapshot));
+        Assert.Equal(MD5.Create().ComputeHash(bigSnapshot), MD5.Create().ComputeHash((byte[])loaded.Snapshot.Snapshot));
     }
 }

--- a/src/Akka.Persistence.MongoDb.Tests/GridFS/MongoDbGridFsSnapshotStoreSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/GridFS/MongoDbGridFsSnapshotStoreSpec.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="MongoDbSnapshotStoreSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 using Akka.Configuration;
 using Akka.Event;
 using Akka.Persistence.TCK.Snapshot;
-using FluentAssertions;
 using Xunit;
 
 #nullable enable
@@ -77,7 +76,6 @@ public class MongoDbGridFsSnapshotStoreSpec : SnapshotStoreSpec, IClassFixture<D
         stopwatch.Stop();
         Log.Info($"{SnapshotByteSizeLimit} bytes snapshot loaded in {stopwatch.Elapsed.Milliseconds} milliseconds");
 
-        MD5.Create().ComputeHash((byte[])loaded.Snapshot.Snapshot).Should()
-            .BeEquivalentTo(MD5.Create().ComputeHash(bigSnapshot));
+        Assert.Equal(MD5.Create().ComputeHash(bigSnapshot), MD5.Create().ComputeHash((byte[])loaded.Snapshot.Snapshot));
     }
 }

--- a/src/Akka.Persistence.MongoDb.Tests/Hosting/EventAdapterRuntimeInvocationSpecs.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/Hosting/EventAdapterRuntimeInvocationSpecs.cs
@@ -11,7 +11,6 @@ using Akka.Persistence.MongoDb.Query;
 using Akka.Persistence.Query;
 using Akka.Streams;
 using Akka.Streams.Dsl;
-using FluentAssertions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Xunit;
 
@@ -133,8 +132,8 @@ public class EventAdapterRuntimeInvocationSpecs : Akka.Hosting.TestKit.TestKit, 
         _output.WriteLine("=== HOCON Configuration ===");
         _output.WriteLine(journalConfig.ToString());
 
-        journalConfig.HasPath("event-adapters").Should().BeTrue("event-adapters should be in HOCON");
-        journalConfig.HasPath("event-adapter-bindings").Should().BeTrue("event-adapter-bindings should be in HOCON");
+        Assert.True(journalConfig.HasPath("event-adapters"));
+        Assert.True(journalConfig.HasPath("event-adapter-bindings"));
 
         // Create persistent actor
         var actor = Sys.ActorOf(Props.Create(() => new TestPersistentActor("test-1")));
@@ -156,11 +155,10 @@ public class EventAdapterRuntimeInvocationSpecs : Akka.Hosting.TestKit.TestKit, 
 
             _output.WriteLine($"Found {taggedEvents.Count()} events with tag 'test-tag'");
 
-            taggedEvents.Count().Should().Be(3,
-                "event adapter should have tagged 3 events - if this fails, the adapter was not invoked at runtime");
+            Assert.Equal(3, taggedEvents.Count());
 
             // Verify the events are the correct type
-            taggedEvents.All(e => e.Event is TestEvent).Should().BeTrue();
+            Assert.True(taggedEvents.All(e => e.Event is TestEvent));
         });
     }
 }

--- a/src/Akka.Persistence.MongoDb.Tests/Hosting/HealthCheckSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/Hosting/HealthCheckSpec.cs
@@ -10,8 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Akka.Hosting;
 using Akka.Persistence.MongoDb.Hosting;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
@@ -64,7 +62,7 @@ public class HealthCheckSpec : Akka.Hosting.TestKit.TestKit, IClassFixture<Datab
         var healthReport = await healthCheckService.CheckHealthAsync(CancellationToken.None);
 
         // Assert - verify that health checks are registered and healthy
-        healthReport.Entries.Should().NotBeEmpty("health checks should be registered");
+        Assert.NotEmpty(healthReport.Entries);
 
         // Debug: print all registered health checks (ALL of them, not just SQL)
         Output?.WriteLine($"Total health checks registered: {healthReport.Entries.Count}");
@@ -79,23 +77,23 @@ public class HealthCheckSpec : Akka.Hosting.TestKit.TestKit, IClassFixture<Datab
             .Where(e => e.Key.Contains("Akka.Persistence", StringComparison.OrdinalIgnoreCase))
             .ToList();
 
-        persistenceHealthChecks.Should().HaveCount(2, "because we registered health checks for both journal and snapshot store");
+        Assert.Equal(2, (persistenceHealthChecks)?.Count());
 
         // Verify journal health check exists and is healthy
         var journalHealthCheck = persistenceHealthChecks
             .FirstOrDefault(e => e.Key.Contains("journal", StringComparison.OrdinalIgnoreCase));
 
-        journalHealthCheck.Should().NotBeNull("journal health check should be registered");
-        journalHealthCheck.Value.Status.Should().Be(HealthStatus.Healthy, "SQL journal should be properly initialized");
+        Assert.NotNull(journalHealthCheck);
+        Assert.Equal(HealthStatus.Healthy, journalHealthCheck.Value.Status);
 
         // Verify snapshot health check exists and is healthy
         var snapshotHealthCheck = persistenceHealthChecks
             .FirstOrDefault(e => e.Key.Contains("snapshot", StringComparison.OrdinalIgnoreCase));
 
-        snapshotHealthCheck.Should().NotBeNull("snapshot health check should be registered");
-        snapshotHealthCheck.Value.Status.Should().Be(HealthStatus.Healthy, "SQL snapshot store should be properly initialized");
+        Assert.NotNull(snapshotHealthCheck);
+        Assert.Equal(HealthStatus.Healthy, snapshotHealthCheck.Value.Status);
 
         // Verify overall health status
-        healthReport.Status.Should().Be(HealthStatus.Healthy, "because all health checks should pass");
+        Assert.Equal(HealthStatus.Healthy, healthReport.Status);
     }
 }

--- a/src/Akka.Persistence.MongoDb.Tests/Hosting/MongoDbConnectivityCheckSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/Hosting/MongoDbConnectivityCheckSpec.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Akka.Hosting;
 using Akka.Persistence.MongoDb.Hosting;
-using FluentAssertions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Xunit;
 
@@ -41,9 +40,9 @@ public class MongoDbConnectivityCheckSpec : IClassFixture<DatabaseFixture>
         var result = await check.CheckHealthAsync(context, CancellationToken.None);
 
         // Assert
-        result.Status.Should().Be(HealthStatus.Healthy);
-        result.Exception.Should().BeNull();
-        result.Description.Should().Contain("successful");
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+        Assert.Null(result.Exception);
+        Assert.Contains("successful", result.Description);
     }
 
     [Fact]
@@ -57,9 +56,9 @@ public class MongoDbConnectivityCheckSpec : IClassFixture<DatabaseFixture>
         var result = await check.CheckHealthAsync(context, CancellationToken.None);
 
         // Assert
-        result.Status.Should().Be(HealthStatus.Healthy);
-        result.Exception.Should().BeNull();
-        result.Description.Should().Contain("successful");
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+        Assert.Null(result.Exception);
+        Assert.Contains("successful", result.Description);
     }
 
     [Fact]
@@ -73,9 +72,9 @@ public class MongoDbConnectivityCheckSpec : IClassFixture<DatabaseFixture>
         var result = await check.CheckHealthAsync(context, CancellationToken.None);
 
         // Assert
-        result.Status.Should().Be(HealthStatus.Healthy);
-        result.Exception.Should().BeNull();
-        result.Description.Should().Contain("successful");
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+        Assert.Null(result.Exception);
+        Assert.Contains("successful", result.Description);
     }
 
     // Unhappy path tests - verify health checks detect connection failures
@@ -90,8 +89,8 @@ public class MongoDbConnectivityCheckSpec : IClassFixture<DatabaseFixture>
         var result = await check.CheckHealthAsync(context, CancellationToken.None);
 
         // Assert
-        result.Status.Should().Be(HealthStatus.Unhealthy);
-        result.Exception.Should().NotBeNull();
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.NotNull(result.Exception);
     }
 
     [Fact]
@@ -105,8 +104,8 @@ public class MongoDbConnectivityCheckSpec : IClassFixture<DatabaseFixture>
         var result = await check.CheckHealthAsync(context, CancellationToken.None);
 
         // Assert
-        result.Status.Should().Be(HealthStatus.Unhealthy);
-        result.Exception.Should().NotBeNull();
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.NotNull(result.Exception);
     }
 
     [Fact]
@@ -114,7 +113,7 @@ public class MongoDbConnectivityCheckSpec : IClassFixture<DatabaseFixture>
     {
         // Act & Assert
         var action = () => new MongoDbJournalConnectivityCheck(null!, "mongodb");
-        action.Should().Throw<ArgumentNullException>().Where(ex => ex.ParamName == "connectionString");
+        Assert.Equal("connectionString", Assert.Throws<ArgumentNullException>(action).ParamName);
     }
 
     [Fact]
@@ -122,7 +121,7 @@ public class MongoDbConnectivityCheckSpec : IClassFixture<DatabaseFixture>
     {
         // Act & Assert
         var action = () => new MongoDbJournalConnectivityCheck("mongodb://localhost", null!);
-        action.Should().Throw<ArgumentNullException>().Where(ex => ex.ParamName == "journalId");
+        Assert.Equal("journalId", Assert.Throws<ArgumentNullException>(action).ParamName);
     }
 
     [Fact]
@@ -130,7 +129,7 @@ public class MongoDbConnectivityCheckSpec : IClassFixture<DatabaseFixture>
     {
         // Act & Assert
         var action = () => new MongoDbSnapshotStoreConnectivityCheck(null!, "mongodb");
-        action.Should().Throw<ArgumentNullException>().Where(ex => ex.ParamName == "connectionString");
+        Assert.Equal("connectionString", Assert.Throws<ArgumentNullException>(action).ParamName);
     }
 
     [Fact]
@@ -138,7 +137,7 @@ public class MongoDbConnectivityCheckSpec : IClassFixture<DatabaseFixture>
     {
         // Act & Assert
         var action = () => new MongoDbSnapshotStoreConnectivityCheck("mongodb://localhost", null!);
-        action.Should().Throw<ArgumentNullException>().Where(ex => ex.ParamName == "snapshotStoreId");
+        Assert.Equal("snapshotStoreId", Assert.Throws<ArgumentNullException>(action).ParamName);
     }
 
     [Fact]
@@ -152,8 +151,8 @@ public class MongoDbConnectivityCheckSpec : IClassFixture<DatabaseFixture>
         var result = await check.CheckHealthAsync(context, CancellationToken.None);
 
         // Assert
-        result.Status.Should().Be(HealthStatus.Unhealthy);
-        result.Exception.Should().NotBeNull();
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.NotNull(result.Exception);
     }
 
     [Fact]
@@ -161,7 +160,7 @@ public class MongoDbConnectivityCheckSpec : IClassFixture<DatabaseFixture>
     {
         // Act & Assert
         var action = () => new MongoDbGridFsSnapshotStoreConnectivityCheck(null!, "mongodb-gridfs");
-        action.Should().Throw<ArgumentNullException>().Where(ex => ex.ParamName == "connectionString");
+        Assert.Equal("connectionString", Assert.Throws<ArgumentNullException>(action).ParamName);
     }
 
     [Fact]
@@ -169,6 +168,6 @@ public class MongoDbConnectivityCheckSpec : IClassFixture<DatabaseFixture>
     {
         // Act & Assert
         var action = () => new MongoDbGridFsSnapshotStoreConnectivityCheck("mongodb://localhost", null!);
-        action.Should().Throw<ArgumentNullException>().Where(ex => ex.ParamName == "snapshotStoreId");
+        Assert.Equal("snapshotStoreId", Assert.Throws<ArgumentNullException>(action).ParamName);
     }
 }

--- a/src/Akka.Persistence.MongoDb.Tests/Hosting/MongoDbJournalOptionsSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/Hosting/MongoDbJournalOptionsSpec.cs
@@ -3,8 +3,6 @@ using System.IO;
 using System.Text;
 using Akka.Configuration;
 using Akka.Persistence.MongoDb.Hosting;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Microsoft.Extensions.Configuration;
 using Xunit;
 
@@ -18,8 +16,8 @@ namespace Akka.Persistence.MongoDb.Tests.Hosting
             var options = new MongoDbJournalOptions(true);
             var config = options.ToConfig();
 
-            config.GetString("akka.persistence.journal.plugin").Should().Be("akka.persistence.journal.mongodb");
-            config.HasPath("akka.persistence.journal.mongodb").Should().BeTrue();
+            Assert.Equal("akka.persistence.journal.mongodb", config.GetString("akka.persistence.journal.plugin"));
+            Assert.True(config.HasPath("akka.persistence.journal.mongodb"));
         }
 
         [Fact(DisplayName = "Empty MongoDbJournalOptions should equal empty config with default fallback")]
@@ -30,24 +28,24 @@ namespace Akka.Persistence.MongoDb.Tests.Hosting
             var baseRootConfig = Config.Empty
                 .WithFallback(MongoDbPersistence.DefaultConfiguration());
 
-            emptyRootConfig.GetString("akka.persistence.journal.plugin").Should().Be(baseRootConfig.GetString("akka.persistence.journal.plugin"));
+            Assert.Equal(baseRootConfig.GetString("akka.persistence.journal.plugin"), emptyRootConfig.GetString("akka.persistence.journal.plugin"));
 
             var config = emptyRootConfig.GetConfig("akka.persistence.journal.mongodb");
             var baseConfig = baseRootConfig.GetConfig("akka.persistence.journal.mongodb");
-            config.Should().NotBeNull();
-            baseConfig.Should().NotBeNull();
+            Assert.NotNull(config);
+            Assert.NotNull(baseConfig);
 
-            config.GetString("class").Should().Be(baseConfig.GetString("class"));
-            config.GetString("connection-string").Should().Be(baseConfig.GetString("connection-string"));
-            config.GetBoolean("use-write-transaction").Should().Be(baseConfig.GetBoolean("use-write-transaction"));
-            config.GetBoolean("use-read-transaction").Should().Be(baseConfig.GetBoolean("use-read-transaction"));
-            config.GetBoolean("read-batch-size").Should().Be(baseConfig.GetBoolean("read-batch-size"));
-            config.GetBoolean("auto-initialize").Should().Be(baseConfig.GetBoolean("auto-initialize"));
-            config.GetString("plugin-dispatcher").Should().Be(baseConfig.GetString("plugin-dispatcher"));
-            config.GetString("collection").Should().Be(baseConfig.GetString("collection"));
-            config.GetString("metadata-collection").Should().Be(baseConfig.GetString("metadata-collection"));
-            config.GetBoolean("legacy-serialization").Should().Be(baseConfig.GetBoolean("legacy-serialization"));
-            config.GetTimeSpan("call-timeout").Should().Be(baseConfig.GetTimeSpan("call-timeout"));
+            Assert.Equal(baseConfig.GetString("class"), config.GetString("class"));
+            Assert.Equal(baseConfig.GetString("connection-string"), config.GetString("connection-string"));
+            Assert.Equal(baseConfig.GetBoolean("use-write-transaction"), config.GetBoolean("use-write-transaction"));
+            Assert.Equal(baseConfig.GetBoolean("use-read-transaction"), config.GetBoolean("use-read-transaction"));
+            Assert.Equal(baseConfig.GetBoolean("read-batch-size"), config.GetBoolean("read-batch-size"));
+            Assert.Equal(baseConfig.GetBoolean("auto-initialize"), config.GetBoolean("auto-initialize"));
+            Assert.Equal(baseConfig.GetString("plugin-dispatcher"), config.GetString("plugin-dispatcher"));
+            Assert.Equal(baseConfig.GetString("collection"), config.GetString("collection"));
+            Assert.Equal(baseConfig.GetString("metadata-collection"), config.GetString("metadata-collection"));
+            Assert.Equal(baseConfig.GetBoolean("legacy-serialization"), config.GetBoolean("legacy-serialization"));
+            Assert.Equal(baseConfig.GetTimeSpan("call-timeout"), config.GetTimeSpan("call-timeout"));
         }
 
         [Fact(DisplayName = "Empty MongoDbJournalOptions with custom identifier should equal empty config with default fallback")]
@@ -58,24 +56,24 @@ namespace Akka.Persistence.MongoDb.Tests.Hosting
             var baseRootConfig = Config.Empty
                 .WithFallback(MongoDbPersistence.DefaultConfiguration());
 
-            emptyRootConfig.GetString("akka.persistence.journal.plugin").Should().Be(baseRootConfig.GetString("akka.persistence.journal.plugin"));
+            Assert.Equal(baseRootConfig.GetString("akka.persistence.journal.plugin"), emptyRootConfig.GetString("akka.persistence.journal.plugin"));
 
             var config = emptyRootConfig.GetConfig("akka.persistence.journal.custom");
             var baseConfig = baseRootConfig.GetConfig("akka.persistence.journal.mongodb");
-            config.Should().NotBeNull();
-            baseConfig.Should().NotBeNull();
+            Assert.NotNull(config);
+            Assert.NotNull(baseConfig);
 
-            config.GetString("class").Should().Be(baseConfig.GetString("class"));
-            config.GetString("connection-string").Should().Be(baseConfig.GetString("connection-string"));
-            config.GetBoolean("use-write-transaction").Should().Be(baseConfig.GetBoolean("use-write-transaction"));
-            config.GetBoolean("use-read-transaction").Should().Be(baseConfig.GetBoolean("use-read-transaction"));
-            config.GetBoolean("read-batch-size").Should().Be(baseConfig.GetBoolean("read-batch-size"));
-            config.GetBoolean("auto-initialize").Should().Be(baseConfig.GetBoolean("auto-initialize"));
-            config.GetString("plugin-dispatcher").Should().Be(baseConfig.GetString("plugin-dispatcher"));
-            config.GetString("collection").Should().Be(baseConfig.GetString("collection"));
-            config.GetString("metadata-collection").Should().Be(baseConfig.GetString("metadata-collection"));
-            config.GetBoolean("legacy-serialization").Should().Be(baseConfig.GetBoolean("legacy-serialization"));
-            config.GetTimeSpan("call-timeout").Should().Be(baseConfig.GetTimeSpan("call-timeout"));
+            Assert.Equal(baseConfig.GetString("class"), config.GetString("class"));
+            Assert.Equal(baseConfig.GetString("connection-string"), config.GetString("connection-string"));
+            Assert.Equal(baseConfig.GetBoolean("use-write-transaction"), config.GetBoolean("use-write-transaction"));
+            Assert.Equal(baseConfig.GetBoolean("use-read-transaction"), config.GetBoolean("use-read-transaction"));
+            Assert.Equal(baseConfig.GetBoolean("read-batch-size"), config.GetBoolean("read-batch-size"));
+            Assert.Equal(baseConfig.GetBoolean("auto-initialize"), config.GetBoolean("auto-initialize"));
+            Assert.Equal(baseConfig.GetString("plugin-dispatcher"), config.GetString("plugin-dispatcher"));
+            Assert.Equal(baseConfig.GetString("collection"), config.GetString("collection"));
+            Assert.Equal(baseConfig.GetString("metadata-collection"), config.GetString("metadata-collection"));
+            Assert.Equal(baseConfig.GetBoolean("legacy-serialization"), config.GetBoolean("legacy-serialization"));
+            Assert.Equal(baseConfig.GetTimeSpan("call-timeout"), config.GetTimeSpan("call-timeout"));
         }
 
         [Fact(DisplayName = "MongoDbJournalOptions should generate proper config")]
@@ -97,21 +95,21 @@ namespace Akka.Persistence.MongoDb.Tests.Hosting
 
             var baseConfig = options.ToConfig();
 
-            baseConfig.GetString("akka.persistence.journal.plugin").Should().Be("akka.persistence.journal.custom");
+            Assert.Equal("akka.persistence.journal.custom", baseConfig.GetString("akka.persistence.journal.plugin"));
 
             var config = baseConfig.GetConfig("akka.persistence.journal.custom");
-            config.Should().NotBeNull();
-            config.GetString("connection-string").Should().Be(options.ConnectionString);
-            config.GetBoolean("auto-initialize").Should().Be(options.AutoInitialize);
-            config.GetString("collection").Should().Be(options.Collection);
-            config.GetString("metadata-collection").Should().Be(options.MetadataCollection);
-            config.GetBoolean("use-write-transaction").Should().Be(options.UseWriteTransaction.Value);
-            config.GetBoolean("use-read-transaction").Should().Be(options.UseReadTransaction.Value);
-            config.GetString("read-batch-size").ToLowerInvariant().Should().NotBe("off");
-            config.GetString("read-batch-size").ToLowerInvariant().Should().NotBe("false");
-            config.GetInt("read-batch-size").Should().Be(options.ReadBatchSize.Value);
-            config.GetBoolean("legacy-serialization").Should().Be(options.LegacySerialization.Value);
-            config.GetTimeSpan("call-timeout").Should().Be(options.CallTimeout.Value);
+            Assert.NotNull(config);
+            Assert.Equal(options.ConnectionString, config.GetString("connection-string"));
+            Assert.Equal(options.AutoInitialize, config.GetBoolean("auto-initialize"));
+            Assert.Equal(options.Collection, config.GetString("collection"));
+            Assert.Equal(options.MetadataCollection, config.GetString("metadata-collection"));
+            Assert.Equal(options.UseWriteTransaction.Value, config.GetBoolean("use-write-transaction"));
+            Assert.Equal(options.UseReadTransaction.Value, config.GetBoolean("use-read-transaction"));
+            Assert.NotEqual("off", config.GetString("read-batch-size").ToLowerInvariant());
+            Assert.NotEqual("false", config.GetString("read-batch-size").ToLowerInvariant());
+            Assert.Equal(options.ReadBatchSize.Value, config.GetInt("read-batch-size"));
+            Assert.Equal(options.LegacySerialization.Value, config.GetBoolean("legacy-serialization"));
+            Assert.Equal(options.CallTimeout.Value, config.GetTimeSpan("call-timeout"));
         }
 
         const string Json = @"
@@ -147,18 +145,18 @@ namespace Akka.Persistence.MongoDb.Tests.Hosting
             var jsonConfig = new ConfigurationBuilder().AddJsonStream(stream).Build();
 
             var options = jsonConfig.GetSection("Akka:JournalOptions").Get<MongoDbJournalOptions>();
-            options.ConnectionString.Should().Be("mongodb://localhost:27017");
-            options.UseWriteTransaction.Should().BeTrue();
-            options.UseReadTransaction.Should().BeTrue();
-            options.ReadBatchSize.Should().Be(16);
-            options.Identifier.Should().Be("custommongodb");
-            options.AutoInitialize.Should().BeTrue();
-            options.IsDefaultPlugin.Should().BeFalse();
-            options.Collection.Should().Be("CustomEnventJournalCollection");
-            options.MetadataCollection.Should().Be("CustomMetadataCollection");
-            options.LegacySerialization.Should().BeTrue();
-            options.CallTimeout.Should().Be(10.Minutes());
-            options.Serializer.Should().Be("hyperion");
+            Assert.Equal("mongodb://localhost:27017", options.ConnectionString);
+            Assert.True(options.UseWriteTransaction);
+            Assert.True(options.UseReadTransaction);
+            Assert.Equal(16, options.ReadBatchSize);
+            Assert.Equal("custommongodb", options.Identifier);
+            Assert.True(options.AutoInitialize);
+            Assert.False(options.IsDefaultPlugin);
+            Assert.Equal("CustomEnventJournalCollection", options.Collection);
+            Assert.Equal("CustomMetadataCollection", options.MetadataCollection);
+            Assert.True(options.LegacySerialization);
+            Assert.Equal(TimeSpan.FromMinutes(10), options.CallTimeout);
+            Assert.Equal("hyperion", options.Serializer);
         }
     }
 }

--- a/src/Akka.Persistence.MongoDb.Tests/Hosting/MongoDbSnapshotOptionsSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/Hosting/MongoDbSnapshotOptionsSpec.cs
@@ -1,10 +1,8 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Text;
 using Akka.Configuration;
 using Akka.Persistence.MongoDb.Hosting;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Microsoft.Extensions.Configuration;
 using Xunit;
 
@@ -18,8 +16,8 @@ namespace Akka.Persistence.MongoDb.Tests.Hosting
             var options = new MongoDbSnapshotOptions(true);
             var config = options.ToConfig();
 
-            config.GetString("akka.persistence.snapshot-store.plugin").Should().Be("akka.persistence.snapshot-store.mongodb");
-            config.HasPath("akka.persistence.snapshot-store.mongodb").Should().BeTrue();
+            Assert.Equal("akka.persistence.snapshot-store.mongodb", config.GetString("akka.persistence.snapshot-store.plugin"));
+            Assert.True(config.HasPath("akka.persistence.snapshot-store.mongodb"));
         }
 
         [Fact(DisplayName = "Empty MongoDbSnapshotOptions with default fallback should return default config")]
@@ -30,22 +28,22 @@ namespace Akka.Persistence.MongoDb.Tests.Hosting
             var baseRootConfig = Config.Empty
                 .WithFallback(MongoDbPersistence.DefaultConfiguration());
 
-            emptyRootConfig.GetString("akka.persistence.snapshot-store.plugin").Should().Be(baseRootConfig.GetString("akka.persistence.snapshot-store.plugin"));
+            Assert.Equal(baseRootConfig.GetString("akka.persistence.snapshot-store.plugin"), emptyRootConfig.GetString("akka.persistence.snapshot-store.plugin"));
 
             var config = emptyRootConfig.GetConfig("akka.persistence.snapshot-store.mongodb");
             var baseConfig = baseRootConfig.GetConfig("akka.persistence.snapshot-store.mongodb");
-            config.Should().NotBeNull();
-            baseConfig.Should().NotBeNull();
+            Assert.NotNull(config);
+            Assert.NotNull(baseConfig);
 
-            Type.GetType(config.GetString("class")).Should().Be(Type.GetType(baseConfig.GetString("class")));
-            config.GetString("connection-string").Should().Be(baseConfig.GetString("connection-string"));
-            config.GetBoolean("use-write-transaction").Should().Be(baseConfig.GetBoolean("use-write-transaction"));
-            config.GetBoolean("use-read-transaction").Should().Be(baseConfig.GetBoolean("use-read-transaction"));
-            config.GetBoolean("auto-initialize").Should().Be(baseConfig.GetBoolean("auto-initialize"));
-            config.GetString("plugin-dispatcher").Should().Be(baseConfig.GetString("plugin-dispatcher"));
-            config.GetString("collection").Should().Be(baseConfig.GetString("collection"));
-            config.GetBoolean("legacy-serialization").Should().Be(baseConfig.GetBoolean("legacy-serialization"));
-            config.GetTimeSpan("call-timeout").Should().Be(baseConfig.GetTimeSpan("call-timeout"));
+            Assert.Equal(Type.GetType(baseConfig.GetString("class")), Type.GetType(config.GetString("class")));
+            Assert.Equal(baseConfig.GetString("connection-string"), config.GetString("connection-string"));
+            Assert.Equal(baseConfig.GetBoolean("use-write-transaction"), config.GetBoolean("use-write-transaction"));
+            Assert.Equal(baseConfig.GetBoolean("use-read-transaction"), config.GetBoolean("use-read-transaction"));
+            Assert.Equal(baseConfig.GetBoolean("auto-initialize"), config.GetBoolean("auto-initialize"));
+            Assert.Equal(baseConfig.GetString("plugin-dispatcher"), config.GetString("plugin-dispatcher"));
+            Assert.Equal(baseConfig.GetString("collection"), config.GetString("collection"));
+            Assert.Equal(baseConfig.GetBoolean("legacy-serialization"), config.GetBoolean("legacy-serialization"));
+            Assert.Equal(baseConfig.GetTimeSpan("call-timeout"), config.GetTimeSpan("call-timeout"));
         }
 
         [Fact(DisplayName = "Empty MongoDbSnapshotOptions with custom identifier should equal empty config with default fallback")]
@@ -56,22 +54,22 @@ namespace Akka.Persistence.MongoDb.Tests.Hosting
             var baseRootConfig = Config.Empty
                 .WithFallback(MongoDbPersistence.DefaultConfiguration());
 
-            emptyRootConfig.GetString("akka.persistence.snapshot-store.plugin").Should().Be(baseRootConfig.GetString("akka.persistence.snapshot-store.plugin"));
+            Assert.Equal(baseRootConfig.GetString("akka.persistence.snapshot-store.plugin"), emptyRootConfig.GetString("akka.persistence.snapshot-store.plugin"));
 
             var config = emptyRootConfig.GetConfig("akka.persistence.snapshot-store.custom");
             var baseConfig = baseRootConfig.GetConfig("akka.persistence.snapshot-store.mongodb");
-            config.Should().NotBeNull();
-            baseConfig.Should().NotBeNull();
+            Assert.NotNull(config);
+            Assert.NotNull(baseConfig);
 
-            Type.GetType(config.GetString("class")).Should().Be(Type.GetType(baseConfig.GetString("class")));
-            config.GetString("connection-string").Should().Be(baseConfig.GetString("connection-string"));
-            config.GetBoolean("use-write-transaction").Should().Be(baseConfig.GetBoolean("use-write-transaction"));
-            config.GetBoolean("use-read-transaction").Should().Be(baseConfig.GetBoolean("use-read-transaction"));
-            config.GetBoolean("auto-initialize").Should().Be(baseConfig.GetBoolean("auto-initialize"));
-            config.GetString("plugin-dispatcher").Should().Be(baseConfig.GetString("plugin-dispatcher"));
-            config.GetString("collection").Should().Be(baseConfig.GetString("collection"));
-            config.GetBoolean("legacy-serialization").Should().Be(baseConfig.GetBoolean("legacy-serialization"));
-            config.GetTimeSpan("call-timeout").Should().Be(baseConfig.GetTimeSpan("call-timeout"));
+            Assert.Equal(Type.GetType(baseConfig.GetString("class")), Type.GetType(config.GetString("class")));
+            Assert.Equal(baseConfig.GetString("connection-string"), config.GetString("connection-string"));
+            Assert.Equal(baseConfig.GetBoolean("use-write-transaction"), config.GetBoolean("use-write-transaction"));
+            Assert.Equal(baseConfig.GetBoolean("use-read-transaction"), config.GetBoolean("use-read-transaction"));
+            Assert.Equal(baseConfig.GetBoolean("auto-initialize"), config.GetBoolean("auto-initialize"));
+            Assert.Equal(baseConfig.GetString("plugin-dispatcher"), config.GetString("plugin-dispatcher"));
+            Assert.Equal(baseConfig.GetString("collection"), config.GetString("collection"));
+            Assert.Equal(baseConfig.GetBoolean("legacy-serialization"), config.GetBoolean("legacy-serialization"));
+            Assert.Equal(baseConfig.GetTimeSpan("call-timeout"), config.GetTimeSpan("call-timeout"));
         }
 
         [Fact(DisplayName = "MongoDbSnapshotOptions should generate proper config")]
@@ -92,17 +90,17 @@ namespace Akka.Persistence.MongoDb.Tests.Hosting
             var baseConfig = options.ToConfig()
                 .WithFallback(MongoDbPersistence.DefaultConfiguration());
 
-            baseConfig.GetString("akka.persistence.snapshot-store.plugin").Should().Be("akka.persistence.snapshot-store.custom");
+            Assert.Equal("akka.persistence.snapshot-store.custom", baseConfig.GetString("akka.persistence.snapshot-store.plugin"));
 
             var config = baseConfig.GetConfig("akka.persistence.snapshot-store.custom");
-            config.Should().NotBeNull();
-            config.GetString("connection-string").Should().Be(options.ConnectionString);
-            config.GetBoolean("auto-initialize").Should().Be(options.AutoInitialize);
-            config.GetString("collection").Should().Be(options.Collection);
-            config.GetBoolean("use-write-transaction").Should().Be(options.UseWriteTransaction.Value);
-            config.GetBoolean("use-read-transaction").Should().Be(options.UseReadTransaction.Value);
-            config.GetBoolean("legacy-serialization").Should().Be(options.LegacySerialization.Value);
-            config.GetTimeSpan("call-timeout").Should().Be(options.CallTimeout.Value);
+            Assert.NotNull(config);
+            Assert.Equal(options.ConnectionString, config.GetString("connection-string"));
+            Assert.Equal(options.AutoInitialize, config.GetBoolean("auto-initialize"));
+            Assert.Equal(options.Collection, config.GetString("collection"));
+            Assert.Equal(options.UseWriteTransaction.Value, config.GetBoolean("use-write-transaction"));
+            Assert.Equal(options.UseReadTransaction.Value, config.GetBoolean("use-read-transaction"));
+            Assert.Equal(options.LegacySerialization.Value, config.GetBoolean("legacy-serialization"));
+            Assert.Equal(options.CallTimeout.Value, config.GetTimeSpan("call-timeout"));
         }
 
         [Fact(DisplayName = "MongoDbSnapshotOptions should be bindable to IConfiguration")]
@@ -136,16 +134,16 @@ namespace Akka.Persistence.MongoDb.Tests.Hosting
             var jsonConfig = new ConfigurationBuilder().AddJsonStream(stream).Build();
 
             var options = jsonConfig.GetSection("Akka:SnapshotOptions").Get<MongoDbSnapshotOptions>();
-            options.ConnectionString.Should().Be("mongodb://localhost:27017");
-            options.UseWriteTransaction.Should().BeTrue();
-            options.UseReadTransaction.Should().BeTrue();
-            options.Identifier.Should().Be("custommongodb");
-            options.AutoInitialize.Should().BeTrue();
-            options.IsDefaultPlugin.Should().BeFalse();
-            options.Collection.Should().Be("CustomEnventJournalCollection");
-            options.LegacySerialization.Should().BeTrue();
-            options.CallTimeout.Should().Be(10.Minutes());
-            options.Serializer.Should().Be("hyperion");
+            Assert.Equal("mongodb://localhost:27017", options.ConnectionString);
+            Assert.True(options.UseWriteTransaction);
+            Assert.True(options.UseReadTransaction);
+            Assert.Equal("custommongodb", options.Identifier);
+            Assert.True(options.AutoInitialize);
+            Assert.False(options.IsDefaultPlugin);
+            Assert.Equal("CustomEnventJournalCollection", options.Collection);
+            Assert.True(options.LegacySerialization);
+            Assert.Equal(TimeSpan.FromMinutes(10), options.CallTimeout);
+            Assert.Equal("hyperion", options.Serializer);
         }
     }
 }

--- a/src/Akka.Persistence.MongoDb.Tests/Hosting/SimplifiedConnectivityCheckApiSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/Hosting/SimplifiedConnectivityCheckApiSpec.cs
@@ -10,7 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Akka.Hosting;
 using Akka.Persistence.MongoDb.Hosting;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
@@ -65,7 +64,7 @@ public class SimplifiedConnectivityCheckApiSpec : Akka.Hosting.TestKit.TestKit, 
         var healthReport = await healthCheckService.CheckHealthAsync(CancellationToken.None);
 
         // Assert
-        healthReport.Entries.Should().NotBeEmpty("health checks should be registered");
+        Assert.NotEmpty(healthReport.Entries);
 
         // Look for connectivity checks
         var journalConnectivityCheck = healthReport.Entries
@@ -76,8 +75,8 @@ public class SimplifiedConnectivityCheckApiSpec : Akka.Hosting.TestKit.TestKit, 
             .FirstOrDefault(e => e.Key.Contains("MongoDB.SnapshotStore", StringComparison.OrdinalIgnoreCase) &&
                                 e.Key.Contains("Connectivity", StringComparison.OrdinalIgnoreCase));
 
-        journalConnectivityCheck.Key.Should().NotBeNull("journal connectivity check should be registered");
-        snapshotConnectivityCheck.Key.Should().NotBeNull("snapshot connectivity check should be registered");
+        Assert.NotNull(journalConnectivityCheck.Key);
+        Assert.NotNull(snapshotConnectivityCheck.Key);
     }
 }
 
@@ -127,12 +126,12 @@ public class CustomConnectivityCheckConfigSpec : Akka.Hosting.TestKit.TestKit, I
         var healthReport = await healthCheckService.CheckHealthAsync(CancellationToken.None);
 
         // Assert
-        healthReport.Entries.Should().NotBeEmpty("health checks should be registered");
+        Assert.NotEmpty(healthReport.Entries);
 
         // Look for the custom named check
         var customCheck = healthReport.Entries
             .FirstOrDefault(e => e.Key == "MyCustomMongoDbJournalCheck");
 
-        customCheck.Key.Should().NotBeNull("custom named health check should be registered");
+        Assert.NotNull(customCheck.Key);
     }
 }

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbSettingsSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbSettingsSpec.cs
@@ -1,12 +1,4 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="MongoDbSettingsSpec.cs" company="Akka.NET Project">
-//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
-//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
-// </copyright>
-//-----------------------------------------------------------------------
-
-using FluentAssertions;
-using FluentAssertions.Extensions;
+using System;
 using Xunit;
 
 namespace Akka.Persistence.MongoDb.Tests
@@ -19,12 +11,12 @@ namespace Akka.Persistence.MongoDb.Tests
         {
             var mongoPersistence = MongoDbPersistence.Get(Sys);
 
-            mongoPersistence.JournalSettings.ConnectionString.Should().Be(string.Empty);
-            mongoPersistence.JournalSettings.AutoInitialize.Should().BeTrue();
-            mongoPersistence.JournalSettings.Collection.Should().Be("EventJournal");
-            mongoPersistence.JournalSettings.MetadataCollection.Should().Be("Metadata");
-            mongoPersistence.JournalSettings.LegacySerialization.Should().BeFalse();
-            mongoPersistence.JournalSettings.CallTimeout.Should().Be(10.Seconds());
+            Assert.Equal(string.Empty, mongoPersistence.JournalSettings.ConnectionString);
+            Assert.True(mongoPersistence.JournalSettings.AutoInitialize);
+            Assert.Equal("EventJournal", mongoPersistence.JournalSettings.Collection);
+            Assert.Equal("Metadata", mongoPersistence.JournalSettings.MetadataCollection);
+            Assert.False(mongoPersistence.JournalSettings.LegacySerialization);
+            Assert.Equal(TimeSpan.FromSeconds(10), mongoPersistence.JournalSettings.CallTimeout);
         }
 
         [Fact]
@@ -32,11 +24,11 @@ namespace Akka.Persistence.MongoDb.Tests
         {
             var mongoPersistence = MongoDbPersistence.Get(Sys);
 
-            mongoPersistence.SnapshotStoreSettings.ConnectionString.Should().Be(string.Empty);
-            mongoPersistence.SnapshotStoreSettings.AutoInitialize.Should().BeTrue();
-            mongoPersistence.SnapshotStoreSettings.Collection.Should().Be("SnapshotStore");
-            mongoPersistence.SnapshotStoreSettings.LegacySerialization.Should().BeFalse();
-            mongoPersistence.SnapshotStoreSettings.CallTimeout.Should().Be(10.Seconds());
+            Assert.Equal(string.Empty, mongoPersistence.SnapshotStoreSettings.ConnectionString);
+            Assert.True(mongoPersistence.SnapshotStoreSettings.AutoInitialize);
+            Assert.Equal("SnapshotStore", mongoPersistence.SnapshotStoreSettings.Collection);
+            Assert.False(mongoPersistence.SnapshotStoreSettings.LegacySerialization);
+            Assert.Equal(TimeSpan.FromSeconds(10), mongoPersistence.SnapshotStoreSettings.CallTimeout);
         }
     }
 }


### PR DESCRIPTION
Migrated all FluentAssertions .Should() calls to xUnit v3 Assert.* equivalents. Removed FluentAssertions package references from all projects.